### PR TITLE
Some videos fail to play on 3Speak.tv web-app

### DIFF
--- a/helper/index.js
+++ b/helper/index.js
@@ -5,6 +5,9 @@ function processFeed(videoFeed) {
   const bugFix = JSON.parse(JSON.stringify(videoFeed));
   let out = [];
   for (let video of bugFix) {
+    if (!(video.status !== undefined && video.status !== null && video.status === 'published')) {
+      continue;
+    }
     let baseUrl;
     let playUrl;
     if(video.upload_type === 'ipfs') {


### PR DESCRIPTION
- https://3speak.tv/watch?v=lindarey/gtqzkvmy 
- this causes website hang. 
- It tries to load unpublished videos. 
- I added a check & fixed.

Check screenshots

![Screenshot 2024-01-18 at 8 39 16 AM](https://github.com/spknetwork/3speak-legacy-frontend/assets/4737312/851e1597-4160-4da3-a7b3-699ec29e00c0)


![Screenshot 2024-01-18 at 8 39 22 AM](https://github.com/spknetwork/3speak-legacy-frontend/assets/4737312/b0d7c4a4-1fee-4922-9829-ef197aee0b95)
