### PR TITLE
`scheduled` and `publish_manual` status for generating feed for publishing videos

### DIFF
--- a/helper/index.js
+++ b/helper/index.js
@@ -5,7 +5,7 @@ function processFeed(videoFeed) {
   const bugFix = JSON.parse(JSON.stringify(videoFeed));
   let out = [];
   for (let video of bugFix) {
-    if (!(video.status !== undefined && video.status !== null && video.status === 'published')) {
+    if (!(video.status !== undefined && video.status !== null && (video.status === 'published' || video.status === 'scheduled' || video.status === 'publish_manual'))) {
       continue;
     }
     let baseUrl;


### PR DESCRIPTION
- Add more status for feed. 
- This will be used when generating data for `scheduled` videos & auto-publishing `publish_manual` videos