### PR TITLE
bug fix for user channel not loading and crashing

### DIFF
--- a/helper/index.js
+++ b/helper/index.js
@@ -10,7 +10,7 @@ function processFeed(videoFeed) {
     }
     let baseUrl;
     let playUrl;
-    if(video.upload_type === 'ipfs') {
+    if(video.upload_type === 'ipfs' && video.thumbnail !== undefined && video.video_v2 !== undefined) {
       baseUrl = `${APP_BUNNY_IPFS_CDN}/ipfs/${video.thumbnail.replace('ipfs://', '')}/`;
       playUrl = `${APP_BUNNY_IPFS_CDN}/ipfs/${video.video_v2.replace('ipfs://', '')}`;
     } else {


### PR DESCRIPTION
It used to crash as follows.

```
unhandledRejection TypeError: Cannot read properties of undefined (reading 'replace')
    at Object.processFeed (/3speak/3speak-legacy-frontend/helper/index.js:15:62)
    at /3speak/3speak-legacy-frontend/routes/users.js:447:26
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
---------------------------------------------
```

With this PR, we fixed it.