### PR TITLE
Support LeoFinance related changes

### DIFF
--- a/helper/mongo.js
+++ b/helper/mongo.js
@@ -220,6 +220,7 @@ const VideoSchema = new mongoose.Schema({
   width: {type: Number, default: null, required: false},     
   height: {type: Number, default: null, required: false},
   isAudio: {type: Boolean, default: false},
+  jsonMetaDataAppName: {type: String, default: null, required: false},
 });
 const PodcastSchema = new mongoose.Schema({
   filename: {type: String, required: true},

--- a/scripts/publish_video/helper.js
+++ b/scripts/publish_video/helper.js
@@ -162,9 +162,14 @@ function buildJSONMetadata(video) {
     videoTags = videoTags.split(",")
   }
 
+  let appName = '3speak/0.3.0';
+  if (video.jsonMetaDataAppName !== null && typeof video.jsonMetaDataAppName === "string" && video.jsonMetaDataAppName.length > 0) {
+    appName = jsonMetaDataAppName;
+  }
+
   return {
     tags: processTags(videoTags),
-    app: '3speak/0.3.0',
+    app: appName,
     type: '3speak/video',
     image: [
       imageUrl


### PR DESCRIPTION
Scripts supporting AppName for JSON MetaData when broadcasting comment on Hive Blockchain
With these changes, if we find dApp's JSON Meta Data Name, we use it instead of `3speak/0.3.0`